### PR TITLE
Let npm resolve those binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
     "release-major": "npm run release -- major",
     "release-minor": "npm run release -- minor",
     "release-patch": "npm run release -- patch",
-    "test": "./node_modules/semistandard/bin/cmd.js && ./node_modules/mocha/bin/mocha",
-    "test-travis": "./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- -R spec"
+    "pretest": "semistandard",
+    "test": "mocha",
+    "test-travis": "istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Npm already resolves the binaries from `/node_modules/.bin` so you can write this even shorter.

`pretest` is always executed before `test`